### PR TITLE
updated gemfile.lock for rubyzip

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,7 @@ GEM
       railties (>= 4.2.0, < 5.1)
     rolify (5.1.0)
     ruby-progressbar (1.8.1)
-    rubyzip (1.2.0)
+    rubyzip (1.2.1)
     safe_yaml (1.0.4)
     sass (3.4.22)
     sass-rails (5.0.6)


### PR DESCRIPTION
Updates rubyzip version used by html2word
